### PR TITLE
Blob Storage Configuration

### DIFF
--- a/tailor-app/backend/blob.py
+++ b/tailor-app/backend/blob.py
@@ -1,0 +1,21 @@
+from azure.storage.blob import BlobServiceClient
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+# connection string
+connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
+blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+
+# container client, either one of the following:
+### pinterest-images
+### user-uploads
+container_name = "user-uploads"
+container_client = blob_service_client.get_container_client(container_name)
+
+# upload file to container
+blob_name = "frankenpet.png"
+blob_path = "/Users/nina/Desktop/frankenpet.png"
+with open(blob_path, "rb") as data:
+    container_client.upload_blob(name=blob_name, data=data)


### PR DESCRIPTION
This PR includes setup for Azure Blob Storage. 

Currently, there are two containers set up:
1) pinterest-images
2) user-uploads

The container will have to be set to either one of these strings upon uploading, as such:
`container_name = "user-uploads"`
`container_client = blob_service_client.get_container_client(container_name)`