### PR TITLE
Redirect to Homepage after export

### DIFF
--- a/tailor-app/frontend/src/components/Board.jsx
+++ b/tailor-app/frontend/src/components/Board.jsx
@@ -300,7 +300,7 @@ const BoardTest = (props) => {
       ])
 
       setSuccessExport(true)
-      setTimeout(() => navigate('/'), 2000)
+      //setTimeout(() => navigate('/'), 2000)
     } catch (error) {
       console.error('Export failed:', error)
     }


### PR DESCRIPTION
This PR comments out a line in the code. Specifically, users are redirected to the homepage currently after clicking 'export', but this change allows them to stay on their board in case they wanted to make more edits!